### PR TITLE
🚀 New Component: Speech-to-Text-Local

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.mule.whisperer</groupId>
     <artifactId>mac-whisperer</artifactId>
-    <version>0.1.0</version>
+    <version>0.1.1</version>
     <packaging>mule-extension</packaging>
     <name>MAC Whisperer</name>
 
@@ -15,7 +15,6 @@
         <artifactId>mule-modules-parent</artifactId>
         <version>1.1.3</version>
     </parent>
-
 
     <properties>
         <muleJavaEeBomVersion>4.6.0</muleJavaEeBomVersion>
@@ -39,6 +38,18 @@
 
     <dependencies>
         <dependency>
+            <groupId>javazoom</groupId>
+            <artifactId>jlayer</artifactId>
+            <version>1.0.1</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.bytedeco</groupId>
+            <artifactId>ffmpeg</artifactId>
+            <version>6.1.1-1.5.10</version>
+        </dependency>
+
+        <dependency>
             <groupId>org.mule.sdk</groupId>
             <artifactId>mule-sdk-api</artifactId>
             <version>0.9.0-rc1</version>
@@ -54,6 +65,13 @@
             <artifactId>commons-io</artifactId>
             <version>2.16.1</version>
         </dependency>
+
+        <dependency>
+            <groupId>io.github.givimad</groupId>
+            <artifactId>whisper-jni</artifactId>
+            <version>1.6.1</version>
+        </dependency>
+
     </dependencies>
     
 	<repositories>
@@ -64,6 +82,7 @@
 			<layout>default</layout>
 		</repository>
 	</repositories>
+
 	<pluginRepositories>
 		<pluginRepository>
 			<id>mulesoft-releases</id>

--- a/src/main/java/com/mule/whisperer/MuleChainVoiceConfiguration.java
+++ b/src/main/java/com/mule/whisperer/MuleChainVoiceConfiguration.java
@@ -15,7 +15,14 @@ public class MuleChainVoiceConfiguration {
   @Parameter
   private String apiKey;
 
+  @Parameter
+   private boolean useLocalWhisper;
+
   public String getApiKey(){
     return apiKey;
+  }
+
+  public boolean isUseLocalWhisper() {
+    return this.useLocalWhisper;
   }
 }

--- a/src/main/java/com/mule/whisperer/helpers/AudioFileReader.java
+++ b/src/main/java/com/mule/whisperer/helpers/AudioFileReader.java
@@ -1,0 +1,112 @@
+package com.mule.whisperer.helpers;
+
+import javazoom.jl.decoder.*;
+import javax.sound.sampled.*;
+import java.io.*;
+import java.nio.*;
+import org.slf4j.*;
+
+public class AudioFileReader {
+
+    /**
+     * Reads an audio file and converts its data into an array of float samples.
+     *
+     * @param audioFilePath the path to the audio file to be read.
+     * @return an array of float values representing the audio samples.
+     * @throws UnsupportedAudioFileException if the audio file format is not supported.
+     * @throws IOException                   if an I/O error occurs during file reading.
+     */
+    public static float[] readFile(String audioFilePath) throws UnsupportedAudioFileException, IOException {
+        // Open the audio file and create an AudioInputStream
+        AudioInputStream audioInputStream = AudioSystem.getAudioInputStream(new File(audioFilePath));
+        
+        // Create a ByteBuffer to read the audio data into
+        ByteBuffer captureBuffer = ByteBuffer.allocate(audioInputStream.available());
+        captureBuffer.order(ByteOrder.LITTLE_ENDIAN); // Ensure the buffer uses little-endian byte order
+        
+        // Read the audio data into the buffer
+        int bytesRead = audioInputStream.read(captureBuffer.array());
+        if (bytesRead == -1) {
+            throw new IOException("Unable to read audio file: " + audioFilePath);
+        }
+
+        // Convert the ByteBuffer to a ShortBuffer for easier processing
+        ShortBuffer shortBuffer = captureBuffer.asShortBuffer();
+        
+        // Create a float array to store the converted audio samples
+        float[] samples = new float[shortBuffer.capacity()];
+        int i = 0;
+        
+        // Convert each short sample to a float value between -1.0f and 1.0f
+        while (shortBuffer.hasRemaining()) {
+            samples[i++] = Math.max(-1f, Math.min(((float) shortBuffer.get()) / (float) Short.MAX_VALUE, 1f));
+        }
+        
+        return samples; // Return the array of audio samples
+    }
+
+    
+    /**
+     * Converts an MP3 file to WAV format.
+     *
+     * @param mp3FilePath the path to the source MP3 file.
+     * @param wavFilePath the path where the converted WAV file should be saved.
+     * @throws IOException                   if an I/O error occurs during conversion.
+     * @throws UnsupportedAudioFileException if the MP3 file format is not supported.
+     */
+    public static void convertMp3ToWav(String mp3FilePath, String wavFilePath) throws IOException, UnsupportedAudioFileException {
+        Mp3ToWavConverter.convertMp3ToWav(mp3FilePath, wavFilePath);
+    }
+}
+
+class Mp3ToWavConverter {
+
+    public static void convertMp3ToWav(String mp3FilePath, String wavFilePath) throws IOException, UnsupportedAudioFileException {
+        try (FileInputStream mp3Stream = new FileInputStream(mp3FilePath);
+             FileOutputStream wavStream = new FileOutputStream(wavFilePath)) {
+
+            Bitstream bitstream = new Bitstream(mp3Stream);
+            Decoder decoder = new Decoder();
+
+            AudioFormat baseFormat = null;
+
+            ByteArrayOutputStream byteOutputStream = new ByteArrayOutputStream();
+            long totalFrames = 0;
+            Header header;
+            
+            while ((header = bitstream.readFrame()) != null) {
+                SampleBuffer output = (SampleBuffer) decoder.decodeFrame(header, bitstream);
+
+                if (baseFormat == null) {
+                    baseFormat = new AudioFormat(
+                        (float) header.frequency(),
+                        16, // 16-bit samples
+                        output.getChannelCount(),
+                        true, // signed
+                        false // little-endian
+                    );
+                }
+
+                byte[] buffer = new byte[output.getBufferLength() * 2]; // Buffer size * 2 for bytes
+                for (int i = 0; i < output.getBufferLength(); i++) {
+                    short val = output.getBuffer()[i];
+                    buffer[2 * i] = (byte) (val & 0x00ff);
+                    buffer[2 * i + 1] = (byte) ((val & 0xff00) >> 8);
+                }
+                byteOutputStream.write(buffer, 0, buffer.length); // write all bytes
+                totalFrames += output.getBufferLength(); // Use buffer length directly
+
+                bitstream.closeFrame();
+            }
+
+            byte[] audioData = byteOutputStream.toByteArray();
+            InputStream byteInputStream = new ByteArrayInputStream(audioData);
+            AudioInputStream audioInputStream = new AudioInputStream(byteInputStream, baseFormat, audioData.length / baseFormat.getFrameSize());
+
+            AudioSystem.write(audioInputStream, AudioFileFormat.Type.WAVE, wavStream);
+
+        } catch (JavaLayerException e) {
+            e.printStackTrace();
+        }
+    }
+}

--- a/src/main/java/com/mule/whisperer/helpers/LocalSTTParamsModelDetails.java
+++ b/src/main/java/com/mule/whisperer/helpers/LocalSTTParamsModelDetails.java
@@ -1,0 +1,71 @@
+package com.mule.whisperer.helpers;
+
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+import org.mule.runtime.api.meta.ExpressionSupport;
+import org.mule.runtime.extension.api.annotation.Expression;
+import org.mule.runtime.extension.api.annotation.param.Optional;
+import org.mule.runtime.extension.api.annotation.param.Parameter;
+import org.mule.runtime.extension.api.annotation.param.display.DisplayName;
+
+public class LocalSTTParamsModelDetails {
+
+   @Parameter
+   @Expression(ExpressionSupport.SUPPORTED)
+   @Optional(defaultValue = "4")
+   private int nThreads;
+
+   @Parameter
+   @Expression(ExpressionSupport.SUPPORTED)
+   @Optional(defaultValue = "en")
+   private String language;
+
+   @Parameter
+   @Expression(ExpressionSupport.SUPPORTED)
+   @Optional(defaultValue = "false")
+   private boolean translate;
+
+   @Parameter
+   @Expression(ExpressionSupport.SUPPORTED)
+   @Optional(defaultValue = "true")
+   private boolean printProgress;
+
+   @Parameter
+   @Expression(ExpressionSupport.SUPPORTED)
+   @Optional(defaultValue = "path/to/your/whisper/model.bin")
+   private String modelPath;
+
+   @Parameter
+   @DisplayName("Audio Format")
+   @Optional(defaultValue = "WAV")
+   private AudioFormat audioFormat;
+
+   public int getNThreads() {
+      return this.nThreads;
+   }
+
+   public String getLanguage() {
+      return this.language;
+   }
+
+   public boolean isTranslate() {
+      return this.translate;
+   }
+
+   public boolean isPrintProgress() {
+      return this.printProgress;
+   }
+
+   public Path getModelPath() {
+      return Paths.get(this.modelPath);
+   }
+
+   public AudioFormat getAudioFormat() {
+      return this.audioFormat;
+   }
+
+   public enum AudioFormat {
+      WAV, MP3
+   }
+}


### PR DESCRIPTION
This pull request introduces a new Speech-to-Text (STT) functionality in local mode for the MuleSoft connector, leveraging the Whisper JNI library. This feature enables the use of Whisper models locally, providing an offline alternative to the OpenAI API. 🖥️

### 🚀 New Component: Speech-to-Text-Local
Component Parameters:
- audioFilePath (String): Local path to the audio file to be converted.
- modelPath (String): Local path to the Whisper model (.bin) used for transcription. The model can be placed either in MuleSoft resources or referenced via an absolute local path.
- LocalSTTParamsModelDetails:
  - nThreads (int): Number of threads used for processing.
  - language (String): Language for transcription.
  - translate (boolean): Option to translate the transcription.
  - printProgress (boolean): Option to display progress during transcription.
 
🎯 Objective:
Enable local transcription of audio files using open-source Whisper models, eliminating the limitations and costs associated with external APIs.

### 🛠️ Technical Details
- Dependency: Utilizes the WhisperJNI library (io.github.givimad.whisperjni).
- Required Environment:
  - Must be compiled with Java 11.
  - MuleSoft runtime environment must support Java 11 or above.
Supported Models: Whisper models from [Whisper.cpp on HuggingFace](https://huggingface.co/ggerganov/whisper.cpp) (binary formats like tiny, small, medium, etc.).

### 🧪 Testing Instructions

1. Environment Setup: Ensure your environment is configured with Java 11 or Java 17. To install the connector:

`mvn clean install -Dmaven.test.skip=true -DskipTests -Djdeps.multiRelease=11`

2. Model Configuration: Download a compatible Whisper model from HuggingFace and configure it using a local path or place it in the mule/src/main/resources directory, using the expression: mule.home ++ "/apps/" ++ app.name ++ "/ggml-tiny.bin"

3. Component Configuration: Set the audioFilePath and modelPath in the Speech-to-Text-Local component.

4. Execution: Deploy the project and run the MuleSoft flow to test the transcription.

Example Configuration:
```json
{
  "audioFilePath": "/Users/aaitouaret/Desktop/MuleChain/output.mp3",
  "nThreads": "4",
  "language": "fr",
  "translate": "false",
  "format": "MP3"
}
```

### 📝 Test Cases
Test with different audio files (supported formats: MP3, WAV).
Evaluate performance by adjusting the number of threads.
### 🌟 Future Enhancements
Add support for more audio formats.
Load models directly from a server or bucket to enhance usability.
### ⚠️ Current Limitations
Currently supports only Whisper models from Whisper.cpp.
Requires runtime environment to be Java 11 or above.

![screen-STT-local](https://github.com/user-attachments/assets/5cc1f944-bb81-4f7f-b4df-7f6470a596ad)

